### PR TITLE
feat: add React 19 compatibility and tidy package config

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-page-tracker",
-  "version": "1.0.0",
+  "version": "0.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "react-page-tracker",
-      "version": "1.0.0",
+      "version": "0.4.1",
       "license": "MIT",
       "dependencies": {
         "react": "^18.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-page-tracker",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "description": "A lightweight, zero-dependency library providing accurate navigation tracking, fixed document.referrer value, and complete history support for React frameworks.",
   "scripts": {
     "dev": "vite",
@@ -36,11 +36,10 @@
     "type": "git",
     "url": "git+https://github.com/hsuanyi-chou/react-page-tracker.git"
   },
-  "dependencies": {
-    "react": "^18.0.0",
-    "react-dom": "^18.0.0"
-  },
+  
   "devDependencies": {
+    "react": "^18.0.0",
+    "react-dom": "^18.0.0",
     "@tanstack/router-devtools": "^1.81.4",
     "@tanstack/router-plugin": "^1.79.0",
     "@testing-library/jest-dom": "^6.6.3",
@@ -67,7 +66,7 @@
     "vite-plugin-dts": "^4.3.0"
   },
   "peerDependencies": {
-    "react": "^18.0.0",
-    "react-dom": "^18.0.0"
+    "react": "^18.0.0 || ^19.0.0",
+    "react-dom": "^18.0.0 || ^19.0.0"
   }
 }

--- a/readme.md
+++ b/readme.md
@@ -22,6 +22,7 @@
 - 💡 Accurately determines whether the current page is the first or last page.
 - 🧭 Offers a complete history browsing record.
 - 🚀 Supports Next.js, Remix, TanStack Query, and React Router.
+- 📦 Compatible with React 18 and React 19.
 - ⚡️ zero deps.
 - ⭐️ typed-safe.
 

--- a/src/page-tracker-store.ts
+++ b/src/page-tracker-store.ts
@@ -18,7 +18,7 @@ export const pageTrackerStore = {
   } as PageTrackerState,
   listeners: new Set<() => void>(),
 
-  // 獲取當前狀態
+  // Get current state
   getState(): PageTrackerState {
     return this.state;
   },
@@ -27,21 +27,22 @@ export const pageTrackerStore = {
     return this.state.pageHistory.slice();
   },
 
-  // 更新狀態並通知所有訂閱者
+  // Update state and notify all subscribers
   setState: (newState: Partial<PageTrackerState>) => {
     pageTrackerStore.state = {
       ...pageTrackerStore.state,
       ...newState,
     } as PageTrackerState;
+    // Notify subscribers on the next animation frame for smoother updates
     requestAnimationFrame(() => {
       pageTrackerStore.listeners.forEach((listener) => listener());
     });
   },
 
-  // 訂閱狀態變化
+  // Subscribe to state changes
   subscribe: (listener: () => void) => {
     pageTrackerStore.listeners.add(listener);
-    return () => pageTrackerStore.listeners.delete(listener); // 返回取消訂閱的函數
+    return () => pageTrackerStore.listeners.delete(listener); // Return an unsubscribe function
   },
 };
 
@@ -60,7 +61,7 @@ export const usePageTrackerStore = <T>(selector: (state: PageTrackerState) => T)
     () => {
       const selected = selector(pageTrackerStore.getState());
 
-      // 僅當選擇的值發生改變時才更新
+      // Update only when the selected value changes
       if (JSON.stringify(lastSelected) !== JSON.stringify(selected)) {
         lastSelected = selected;
       }


### PR DESCRIPTION
- Allow react and react-dom ^18.0.0 || ^19.0.0 in peerDependencies
- Move react and react-dom from dependencies to devDependencies to avoid bundling and let consumers control version
- Bump package version to 0.5.0 (semver minor) for compatibility expansion
- Update README to state React 18/19 compatibility
- Translate non-English comments